### PR TITLE
Correct mismatched parentheses in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ function main(sources) {
 }
 
 run(main, {
-  react: makeReactNativeDriver('MyApp')),
+  react: makeReactNativeDriver('MyApp'),
 });
 ```
 


### PR DESCRIPTION
I've found the very first example won't work when pasted. It should be an obstacle for beginners.